### PR TITLE
create v1.22.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-upload_channels:
-  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "streamlit" %}
-{% set version = "1.24.1" %}
+{% set version = "1.22.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: "fd5f0b64798e9706364408fb589b77595314a6315d13b2d750b963c7ae97f362"
+  sha256: "5bef9bf8deef32814d9565c9df48331e6357eb0b90dabc3ec4f53c44fb34fc73"
 
 build:
   number: 0
@@ -23,33 +23,33 @@ requirements:
     - wheel
     - setuptools
   run:
-    - python <3.9.7,>3.9.7,<4.0
-    - altair >=4.0,<6
-    - blinker >=1.0.0,<2
-    - cachetools >=4.0,<6
-    - click >=7.0,<9
-    - importlib-metadata >=1.4,<7
+    - python !=3.9.7
+    - altair >=3.2.0,<5
+    - blinker >=1.0.0
+    - cachetools >=4.0
+    - click >=7.0
+    - importlib-metadata >=1.4
     - numpy
-    - packaging >=14.1,<24
-    - pandas >=0.25.0,<3
-    - pillow >=6.2.0,<10
-    - protobuf >=3.20,<5
+    - packaging >=14.1
+    - pandas >=0.25,<3
+    - pillow >=6.2.0
+    - protobuf >=3.12,<4
     - pyarrow >=4.0
-    - pympler >=0.9,<2
-    - python-dateutil >=2,<3
-    - requests >=2.4,<3
-    - rich >=10.11.0,<14
+    - pympler >=0.9
+    - python-dateutil
+    - requests >=2.4
+    - rich >=10.11.0
     - tenacity >=8.0.0,<9
-    - toml <2
-    - typing_extensions >=4.0.1,<5
-    - tzlocal >=1.1,<5
-    - validators >=0.2,<1
+    - toml
+    - typing_extensions >=3.10.0.0
+    - tzlocal >=1.1
+    - validators >=0.2
     - watchdog  # [not osx]
     # Snowpark extra dependencies are gitpython, pydeck, and tornado:
     # Pin GitPython version not equal to 3.1.19 to avoid builds crush, see https://github.com/streamlit/streamlit/pull/3599
-    - gitpython >=3,<4,!=3.1.19
-    - pydeck >=0.1.dev5,<1
-    - tornado >=6.0.3,<7
+    - gitpython !=3.1.19
+    - pydeck >=0.1.dev5
+    - tornado >=6.0.3
 
 test:
   imports:


### PR DESCRIPTION
streamlit 1.22.0 for ❄️ 
- [upstream](https://github.com/streamlit/streamlit/tree/1.22.0)
- [requirements](https://github.com/streamlit/streamlit/blob/1.22.0/lib/setup.py)
- I wanted to take out from runtime dependencies https://github.com/streamlit/streamlit/blob/3f6e47e7aa53c1419ec8d432671d86c205da48e9/lib/setup.py#L62 but then pip check does not work

