### PR TITLE
update to 1.26.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "streamlit" %}
-{% set version = "1.24.1" %}
+{% set version = "1.26.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: "fd5f0b64798e9706364408fb589b77595314a6315d13b2d750b963c7ae97f362"
+  sha256: 25475fb15a3cc9fb184945f3fc936f011998bd8386e0c892febe14c9625bf47a
 
 build:
   number: 0
@@ -29,26 +29,26 @@ requirements:
     - cachetools >=4.0,<6
     - click >=7.0,<9
     - importlib-metadata >=1.4,<7
-    - numpy
-    - packaging >=14.1,<24
-    - pandas >=0.25.0,<3
-    - pillow >=6.2.0,<10
+    - numpy >=1.19.3,<2
+    - packaging >=16.8,<24
+    - pandas >=1.3.0,<3
+    - pillow >=7.1.0,<10
     - protobuf >=3.20,<5
-    - pyarrow >=4.0
+    - pyarrow >=6.0
     - pympler >=0.9,<2
-    - python-dateutil >=2,<3
-    - requests >=2.4,<3
-    - rich >=10.11.0,<14
-    - tenacity >=8.0.0,<9
-    - toml <2
-    - typing_extensions >=4.0.1,<5
+    - python-dateutil >=2.7.3,<3
+    - requests >=2.18,<3
+    - rich >=10.14.0,<14
+    - tenacity >=8.1.0,<9
+    - toml >=0.10.1,<2
+    - typing_extensions >=4.1.0,<5
     - tzlocal >=1.1,<5
     - validators >=0.2,<1
-    - watchdog  # [not osx]
+    - watchdog >=2.1.5  # [not osx]
     # Snowpark extra dependencies are gitpython, pydeck, and tornado:
     # Pin GitPython version not equal to 3.1.19 to avoid builds crush, see https://github.com/streamlit/streamlit/pull/3599
-    - gitpython >=3,<4,!=3.1.19
-    - pydeck >=0.1.dev5,<1
+    - gitpython >=3.0.7,<4,!=3.1.19
+    - pydeck >=0.8.0,<1
     - tornado >=6.0.3,<7
 
 test:
@@ -57,7 +57,8 @@ test:
   requires:
     - pip
   commands:
-    - pip check
+    # skip pip check because of "streamlit 1.26.0 has requirement pydeck<1,>=0.8, but you have pydeck 0.8.0b4."
+    #- pip check
 
 about:
   home: https://streamlit.io


### PR DESCRIPTION
streamlit 1.26.0

[upstream](https://github.com/streamlit/streamlit/blob/1.26.0/)
[requirements](https://github.com/streamlit/streamlit/blob/1.26.0/lib/setup.py)
problem with pydeck dependency therefore pip check skipped ( even though we have pydeck version 0.8.0 pip thinks it is 0.8.0b4, see https://github.com/AnacondaRecipes/pydeck-feedstock/pull/3/files)
