### PR TITLE
streamlit 1.37.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-channels:
+upload_channels:
 - psteyer

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+- psteyer

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-channels:
-  - psteyer-tests
-upload_without_merge: True
-
-

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,5 @@
 channels:
-- psteyer
+    psteyer: psteyer-tests
 upload_without_merge: True
+
+

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,3 @@
 upload_channels:
 - psteyer
+upload_without_merge: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,5 @@
 channels:
-    psteyer: psteyer-tests
+  - psteyer-tests
 upload_without_merge: True
 
 

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,3 @@
-upload_channels:
+channels:
 - psteyer
 upload_without_merge: True

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "streamlit" %}
-{% set version = "1.32.0" %}
+{% set version = "1.37.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 65bf22e190de973b910c0b127b33d80d31c5275ed891c6fde740de46e5e05323
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+    sha256: 463ef728ba21e74e05122e3704e8af644a7bdbb5822e281b8daf4a0a48761879
 
 build:
   number: 0
@@ -28,18 +28,18 @@ requirements:
     - blinker >=1.0.0,<2
     - cachetools >=4.0,<6
     - click >=7.0,<9
-    - numpy >=1.19.3,<2
-    - packaging >=16.8,<24
+    - numpy >=1.20,<3
+    - packaging >=20,<25
     - pandas >=1.3.0,<3
     - pillow >=7.1.0,<11
-    - protobuf >=3.20,<5
+    - protobuf >=3.20,<6
     - pyarrow >=7.0
     - requests >=2.27,<3
     - rich >=10.14.0,<14
     - tenacity >=8.1.0,<9
     - toml >=0.10.1,<2
     - typing_extensions >=4.3.0,<5
-    - watchdog >=2.1.5  # [not osx]
+    - watchdog >=2.1.5,<5  # [not osx]
     - gitpython >=3.0.7,<4,!=3.1.19
     - pydeck >=0.8.0,<1
     - tornado >=6.0.3,<7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "streamlit" %}
-{% set version = "1.37.0" %}
+{% set version = "1.37.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 463ef728ba21e74e05122e3704e8af644a7bdbb5822e281b8daf4a0a48761879
+  sha256: bc7e3813d94a39dda56f15678437eb37830973c601e8e574f2225a7bf188ea5a
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,11 +19,11 @@ build:
 requirements:
   host:
     - pip
-    - python !=3.9.7
+    - python
     - wheel
     - setuptools
   run:
-    - python !=3.9.7
+    - python
     - altair >=4.0,<6
     - blinker >=1.0.0,<2
     - cachetools >=4.0,<6
@@ -43,6 +43,10 @@ requirements:
     - gitpython >=3.0.7,<4,!=3.1.19
     - pydeck >=0.8.0,<1
     - tornado >=6.0.3,<7
+  run_constrained:
+    - snowflake-snowpark-python >=0.9.0 # [py<312]
+    - snowflake-connector-python >=2.8.0 # [py<312]
+    - python !=3.9.7
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - streamlit = streamlit.web.cli:main
-  skip: true  # [s390x or py<=38]
+  skip: true  # [s390x or py<38]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,16 +14,16 @@ build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - streamlit = streamlit.web.cli:main
-  skip: true  # [s390x or py<38]
+  skip: true  # [s390x or py<=38]
 
 requirements:
   host:
     - pip
-    - python
+    - python !=3.9.7
     - wheel
     - setuptools
   run:
-    - python
+    - python !=3.9.7
     - altair >=4.0,<6
     - blinker >=1.0.0,<2
     - cachetools >=4.0,<6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: 463ef728ba21e74e05122e3704e8af644a7bdbb5822e281b8daf4a0a48761879
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 463ef728ba21e74e05122e3704e8af644a7bdbb5822e281b8daf4a0a48761879
 
 build:
   number: 0


### PR DESCRIPTION
streamlit 1.37.1

**Destination channel:** Defaults

### Links

- [PKG-5416]
- dev_url:        https://github.com/streamlit/streamlit/tree/release/1.37.1
- conda_forge:    None
- pypi:           https://pypi.org/project/streamlit/1.37.0
- pypi inspector: https://inspector.pypi.io/project/streamlit/1.37.0/
- related PR: https://github.com/AnacondaRecipes/st-theme-feedstock/pull/1
                     https://github.com/AnacondaRecipes/streamlit-navigation-bar-feedstock/pull/1

### Explanation of changes:

- updated version and dependency pinnings
- added python constraint
    - https://github.com/streamlit/streamlit/blob/200f5cfca44d19176972bd9ecb414bfc8b411841/lib/setup.py#L143


[PKG-5416]: https://anaconda.atlassian.net/browse/PKG-5416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ