### PR TITLE
re-merge 1.39.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -220,6 +220,7 @@ about:
   doc_url: https://docs.streamlit.io/
   dev_url: https://github.com/streamlit/streamlit
 
+
 extra:
   recipe-maintainers:
     - raybellwaves


### PR DESCRIPTION
Merging again as previous merge failed due to lack of 1.39.0 in aggregate.