### PR TITLE
PKG-8208: streamlit 1.45.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "streamlit" %}
-{% set version = "1.45.0" %}
+{% set version = "1.45.1" %}
 
 package:
   name: {{ name|lower }}-split
@@ -7,10 +7,10 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: 4e99014e113a11a7163b9da5ac079efb1ae5f8575a09c5a6a9c43cd6877a2a88
+    sha256: e37d56c0af5240dbc240976880e81366689c290a559376417246f9b3f51b4217
     folder: streamlit
   - url: https://github.com/{{ name }}/{{ name }}/archive/{{ version }}.tar.gz
-    sha256: 98a556db5b02d9ad9c99add05d39f009b8dde9a71ad4bfe5cfd0fc341aec1439
+    sha256: 94e868db467ee51de31e1de9da74b2f54b03fa466c426287a1e2c6b687b8d7e8
     folder: streamlit_tests
 
 build:


### PR DESCRIPTION
streamlit 1.45.1

**Destination channel:** defaults

### Links

- [PKG-8208](https://anaconda.atlassian.net/browse/PKG-8208) 
- [Upstream repository](https://github.com/streamlit/streamlit/tree/1.45.1)

### Explanation of changes:
- Bump version

[PKG-8208]: https://anaconda.atlassian.net/browse/PKG-8208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ