### PR TITLE
rebuild with optional pydeck

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/0001-make-pydeck-optional.patch
+++ b/recipe/0001-make-pydeck-optional.patch
@@ -1,0 +1,43 @@
+From ec3e2631ae789582da68df023074c0844a1c6985 Mon Sep 17 00:00:00 2001
+From: Charles Bousseau <cbousseau@anaconda.com>
+Date: Fri, 30 May 2025 15:38:05 -0400
+Subject: [PATCH] make pydeck optional
+
+---
+ lib/setup.py | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/lib/setup.py b/lib/setup.py
+index f600acfc7..f5e9cfbbc 100644
+--- a/lib/setup.py
++++ b/lib/setup.py
+@@ -62,7 +62,6 @@ INSTALL_REQUIRES = [
+ # `pip install streamlit` or `conda install -c conda-forge streamlit`)
+ SNOWPARK_CONDA_EXCLUDED_DEPENDENCIES = [
+     "gitpython>=3.0.7, <4, !=3.1.19",
+-    "pydeck>=0.8.0b4, <1",
+     # Tornado 6.0.3 was the current version when Python 3.8 was released (Oct 14, 2019).
+     "tornado>=6.0.3, <7",
+ ]
+@@ -74,11 +73,17 @@ EXTRA_REQUIRES = {
+     "snowflake": [
+         "snowflake-snowpark-python[modin]>=1.17.0; python_version<'3.12'",
+         "snowflake-connector-python>=3.3.0; python_version<'3.12'",
++    ],
++    # pydeck 0.9.1 and below restrict ipywidgets to version 7
++    # This leads to non-functional systems when installed with recent jupyterlab versions.
++    # Pydeck supports creating interactive map visualization, which is not the main feature of streamlit.
++    "pydeck": [
++        "pydeck>=0.8.0b4, <1",
+     ]
+ }
+ 
+ 
+-class VerifyVersionCommand(install):
++class VerifyVersionCommand(install):#
+     """Custom command to verify that the git tag matches our version."""
+ 
+     description = "verify that the git tag matches our version"
+-- 
+2.39.5 (Apple Git-154)
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,12 +9,14 @@ source:
   - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
     sha256: e37d56c0af5240dbc240976880e81366689c290a559376417246f9b3f51b4217
     folder: streamlit
+    patches:
+      - 0001-make-pydeck-optional.patch
   - url: https://github.com/{{ name }}/{{ name }}/archive/{{ version }}.tar.gz
     sha256: 94e868db467ee51de31e1de9da74b2f54b03fa466c426287a1e2c6b687b8d7e8
     folder: streamlit_tests
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<39]
 
 requirements:
@@ -54,12 +56,13 @@ outputs:
         - typing_extensions >=4.4.0,<5
         - watchdog >=2.1.5,<7  # [not osx]
         - gitpython >=3.0.7,<4,!=3.1.19
-        - pydeck >=0.8.0b4,<1
         - tornado >=6.0.3,<7
       run_constrained:
         - snowflake-snowpark-python >=1.17.0  # [py<312]
         - snowflake-connector-python >=3.3.0  # [py<312]
         - python !=3.9.7
+        # todo: remove this once pydeck becomes compatible with ipywidgets 8
+        - pydeck >=0.8.0b4,<1
     test:
       imports:
         - streamlit
@@ -185,6 +188,7 @@ outputs:
         - requests-mock
         - watchdog >=2.1.5
         - plotly >=5.3.1
+        - pydeck
         - testfixtures
         - matplotlib-base >=3.3.4
         - hypothesis >=6.17.4


### PR DESCRIPTION
rebuild with optional pydeck

https://anaconda.atlassian.net/browse/PKG-8319

Streamlit depends on pydeck which depends on ipywidgets <8. 
Streamlit and jupyterlab are both part of the anaconda metapackage. 
Jupyterlab widgets are broken with ipywidgets 7. 
Pydeck supports map visualization on streamlit. By making pydeck optional, we can deliver a metapackage with a functional jupyterlab.

Addresses:
https://github.com/ContinuumIO/anaconda-issues/issues/13453
https://github.com/ContinuumIO/anaconda-issues/issues/13463

