### PR TITLE
streamlit 1.48.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "streamlit" %}
-{% set version = "1.47.0" %}
+{% set version = "1.48.0" %}
 
 package:
   name: {{ name|lower }}-split
@@ -7,12 +7,12 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: b4ff3b8fa01de1e1dc572930b420897f0870ed2ae44e23a815999b62c0778c30
+    sha256: 64da4819f4b897c8d1e9eb6396f4618b2eb5029d25af61472422d4eb0688bb75
     folder: streamlit
     patches:
       - patches/0001-move-pydeck-to-extra-deps.patch
   - url: https://github.com/{{ name }}/{{ name }}/archive/{{ version }}.tar.gz
-    sha256: 222bf535d21a41e42132385bbcfd7e048be8ff4a24587407f958bf59dc5f5dc7
+    sha256: 67dc94d90e89f7b77df85e64fb8f6cf9353e9e0d53e59f6d47c5834e013d6142
     folder: streamlit_tests
 
 build:
@@ -45,7 +45,10 @@ outputs:
         - setuptools
       run:
         - python
-        - altair >=4.0,<6
+        # Altair 5.4.0 and 5.4.1 have compatibility issues with narwhals library
+        # that cause st.line_chart and other built-in charts to fail rendering.
+        # See: https://github.com/streamlit/streamlit/issues/12064
+        - altair >=4.0,<6,!=5.4.0,!=5.4.1
         - blinker >=1.5.0,<2
         - cachetools >=4.0,<7
         - click >=7.0,<9
@@ -81,14 +84,25 @@ outputs:
         # See https://github.com/tornadoweb/tornado/commit/62c276434dc5b13e10336666348408bf8c062391
         - tornado >=6.0.3,<7,!=6.5.0
       run_constrained:
+        - python !=3.9.7
+        - rich >=11.0.0
+        # snowflake
         - snowflake-snowpark-python >=1.17.0  # [py<312]
         - snowflake-connector-python >=3.3.0  # [py<312]
-        - python !=3.9.7
         # SNOWPARK_CONDA_EXCLUDED_DEPENDENCIES:
         # pydeck 0.9.1 and below restrict ipywidgets to version 7
         # This leads to non-functional systems when installed with recent jupyterlab versions.
         # Pydeck supports creating interactive map visualization, which is not the main feature of streamlit.
         - pydeck >=0.8.0b4,<1
+        # auth
+        - authlib >=1.3.2
+        # charts
+        - matplotlib-base >=3.0.0
+        - python-graphviz >=0.19.0
+        - plotly >=4.0.0
+        - orjson >=3.5.0
+        # sql
+        - sqlalchemy >=2.0.0
 
     test:
       imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,9 +35,6 @@ outputs:
       entry_points:
         - streamlit = streamlit.web.cli:main
     requirements:
-      build:
-        - patch  # [not win]
-        - m2-patch  # [win]
       host:
         - pip
         - python

--- a/recipe/patches/0001-move-pydeck-to-extra-deps.patch
+++ b/recipe/patches/0001-move-pydeck-to-extra-deps.patch
@@ -1,6 +1,6 @@
-From aef40888f4375c2d184d61ae393dd2e2dae813c6 Mon Sep 17 00:00:00 2001
+From 3d6f286b4240cc32157e54e5c0ad080258711848 Mon Sep 17 00:00:00 2001
 From: Andrii Osipov <aosipov@anaconda.com>
-Date: Thu, 19 Jun 2025 01:47:58 -0700
+Date: Thu, 7 Aug 2025 00:02:06 -0700
 Subject: [PATCH] move pydeck to extra deps
 
 ---
@@ -8,10 +8,10 @@ Subject: [PATCH] move pydeck to extra deps
  1 file changed, 7 insertions(+), 1 deletion(-)
 
 diff --git a/setup.py b/setup.py
-index 1da6d59..e5a9d2c 100644
+index 751e2fc..3835c1b 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -64,7 +64,7 @@ INSTALL_REQUIRES = [
+@@ -67,7 +67,7 @@ INSTALL_REQUIRES = [
  # `pip install streamlit` or `conda install -c conda-forge streamlit`)
  SNOWPARK_CONDA_EXCLUDED_DEPENDENCIES = [
      "gitpython>=3.0.7, <4, !=3.1.19",
@@ -20,19 +20,19 @@ index 1da6d59..e5a9d2c 100644
      # Tornado 6.0.3 was the current version when Python 3.8 was released (Oct 14, 2019).
      # Tornado 6.5.0 is skipped due to a bug with Unicode characters in the filename.
      # See https://github.com/tornadoweb/tornado/commit/62c276434dc5b13e10336666348408bf8c062391
-@@ -78,6 +78,12 @@ EXTRA_REQUIRES = {
-     "snowflake": [
+@@ -83,6 +83,12 @@ EXTRA_REQUIRES = {
          "snowflake-snowpark-python[modin]>=1.17.0; python_version<'3.12'",
          "snowflake-connector-python>=3.3.0; python_version<'3.12'",
-+    ],
+     ],
 +    # pydeck 0.9.1 and below restrict ipywidgets to version 7
 +    # This leads to non-functional systems when installed with recent jupyterlab versions.
 +    # Pydeck supports creating interactive map visualization, which is not the main feature of streamlit.
 +    "visualization": [
 +        "pydeck>=0.8.0b4, <1",
-     ]
- }
- 
++    ],
+     # Optional dependency required for auth:
+     "auth": [
+         "Authlib>=1.3.2",
 -- 
 2.39.3 (Apple Git-146)
 


### PR DESCRIPTION
streamlit 1.48.0 

**Destination channel:** Defaults

### Links

- [PKG-9110]
- dev_url:        https://github.com/streamlit/streamlit/tree/1.48.0
- conda_forge:    https://github.com/conda-forge/streamlit-feedstock
- pypi:           https://pypi.org/project/streamlit/1.48.0
- pypi inspector: https://inspector.pypi.io/project/streamlit/1.48.0

### Explanation of changes:

- new version number


[PKG-9110]: https://anaconda.atlassian.net/browse/PKG-9110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ