### PR TITLE
streamlit 1.56.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "streamlit" %}
-{% set version = "1.55.0" %}
+{% set version = "1.56.0" %}
 
 package:
   name: {{ name|lower }}-split
@@ -7,12 +7,12 @@ package:
 
 source:
   - url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: 015e512bbd02d000f4047e51118dc086b70e7d9c46b4a11a33c2509731379626
+    sha256: 1176acfa89ae1318b79078e8efe689a9d02e8d58e325c00fc0e55fa2f3fe8d6a
     folder: streamlit
     patches:
       - patches/0001-move-pydeck-to-extra-deps.patch
   - url: https://github.com/{{ name }}/{{ name }}/archive/{{ version }}.tar.gz
-    sha256: ef6452aae7f8aefd48e4f54bfa4d1ba9bd721d16923338890eaff5f8b05ed341
+    sha256: 074a0d53e29c3f7fe76f8b3e99267deaa22227cd2efe9907401344cac1cd78c0
     folder: streamlit_tests
 
 build:
@@ -49,14 +49,16 @@ outputs:
         - blinker >=1.5.0,<2
         - cachetools >=5.5,<8
         - click >=7.0,<9
+        - gitpython >=3.0.7,<4,!=3.1.19
         - numpy >=1.23,<3
         - packaging >=20
         # Pandas <1.4 has a bug related to deleting columns in a DataFrame changing
         # the index dtype.
-        - pandas >=1.4.0,<3
+        - pandas >=1.4.0,<4
         - pillow >=7.1.0,<13
+        - pydeck >=0.8.0b4,<1
         # `protoc` < 3.20 is not able to generate protobuf code compatible with protobuf >= 3.20.
-        - protobuf >=3.20,<7
+        - protobuf >=3.20,<8
         # pyarrow is not semantically versioned, gets new major versions frequently, and
         # doesn't tend to break the API on major version upgrades, so we don't put an
         # upper bound on it.
@@ -66,20 +68,15 @@ outputs:
         # Starting from Python 3.11, Python has built in support for reading TOML files.
         # Let's make sure to remove this "toml" library when we stop supporting Python 3.10.
         - toml >=0.10.1,<2
-        - typing_extensions >=4.10.0,<5
-        # Don't require watchdog on MacOS, since it'll fail without xcode tools.
-        # Without watchdog, we fallback to a polling file watcher to check for app changes.
-        - watchdog >=2.1.5,<7  # [not osx]
-        # SNOWPARK_CONDA_EXCLUDED_DEPENDENCIES:
-        # We want to exclude some dependencies in our internal Snowpark conda distribution of
-        # Streamlit. These dependencies will be installed normally for both regular conda builds
-        # and PyPI builds (that is, for people installing streamlit using either
-        # `pip install streamlit` or `conda install -c conda-forge streamlit`)
-        - gitpython >=3.0.7,<4,!=3.1.19
         # Tornado 6.0.3 was the current version when Python 3.8 was released (Oct 14, 2019).
         # Tornado 6.5.0 is skipped due to a bug with Unicode characters in the filename.
         # See https://github.com/tornadoweb/tornado/commit/62c276434dc5b13e10336666348408bf8c062391
         - tornado >=6.0.3,<7,!=6.5.0
+        # Starlette requires typing-extensions >= 4.10.
+        - typing_extensions >=4.10.0,<5
+        # Don't require watchdog on MacOS, since it'll fail without xcode tools.
+        # Without watchdog, we fallback to a polling file watcher to check for app changes.
+        - watchdog >=2.1.5,<7  # [not osx]
       run_constrained:
         # snowflake
         - snowflake-snowpark-python >=1.17.0  # [py<312]
@@ -93,11 +90,6 @@ outputs:
         - itsdangerous >=2.1.2
         # pdf
         - streamlit-pdf >=1.0.0
-        # SNOWPARK_CONDA_EXCLUDED_DEPENDENCIES:
-        # pydeck 0.9.1 and below restrict ipywidgets to version 7
-        # This leads to non-functional systems when installed with recent jupyterlab versions.
-        # Pydeck supports creating interactive map visualization, which is not the main feature of streamlit.
-        - pydeck >=0.8.0b4,<1
         # auth
         - authlib >=1.3.2
         # charts


### PR DESCRIPTION
streamlit 1.56.0 

**Destination channel:** Defaults

### Links

- [PKG-14356]
- dev_url:        https://github.com/streamlit/streamlit/tree/1.56.0
- conda_forge:    https://github.com/conda-forge/streamlit-feedstock
- pypi:           https://pypi.org/project/streamlit/1.56.0
- pypi inspector: https://inspector.pypi.io/project/streamlit/1.56.0

### Explanation of changes:

- new version number


[PKG-14356]: https://anaconda.atlassian.net/browse/PKG-14356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ